### PR TITLE
Cellular: Make ATHandler:cmd_start() virtual

### DIFF
--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -226,7 +226,7 @@ public:
      *
      *  @param cmd  AT command to be written to modem
      */
-    void cmd_start(const char *cmd);
+    virtual void cmd_start(const char *cmd);
 
     /** Writes integer type AT command subparameter. Starts with the delimiter if not the first param after cmd_start.
      *  In case of failure when writing, the last error is set to NSAPI_ERROR_DEVICE_ERROR.


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Ublox cellular modems, in particular SARA-R4, feature a proprietary power saving mode also known as idle mode. This idle mode is not to be confused with 3GPP Power Saving Mode. It can be enabled or disabled using AT+UPSV command. Once the idle mode is enabled, modem goes to sleep mode if there is an inactivity on serial interface between modem and hostMCU for more than 6 seconds.

The mechanism to wake the modem up from sleep mode is to send a character (e.g. 'A') to the modem before sending the actual AT command. However modem takes a while (~1ms) before it is ready to accept AT commands. This mean that to communicate with the modem while it is asleep, we need to send AT command like this: 
Send 'A'
Delay(1)
Send <AT_command>

In order to incorporate the wake-up mechanism, we need to make the ATHandler::cmd_start() virtual so that it can be overridden with our own implementation. This means that modem will always be waken up irrespective of the AT_xxxxxxx class from where function call is made. 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

